### PR TITLE
Fix for SCPSL 14.0 | Replace SpawnableTeamType with Factions

### DIFF
--- a/SCPDiscordPlugin/EventListeners/PlayerEventListener.cs
+++ b/SCPDiscordPlugin/EventListeners/PlayerEventListener.cs
@@ -300,7 +300,7 @@ namespace SCPDiscord.EventListeners
       {
         { "players", ev.Players.Select(x => x.Nickname).ToString() }
       };
-      SCPDiscord.SendMessage(ev.Team == SpawnableTeamType.ChaosInsurgency ? "messages.onteamrespawn.ci" : "messages.onteamrespawn.mtf", variables);
+      SCPDiscord.SendMessage(ev.Team == Faction.FoundationEnemy ? "messages.onteamrespawn.ci" : "messages.onteamrespawn.mtf", variables);
     }
 
     [PluginEvent]


### PR DESCRIPTION
Quick fix for SCP:SL 14.0, where SpawnableTeamType are now Factions.

This is just so that the dev branch is atleast runnable in SCP:SL 14.0 without any errors, tested in a server with 35 players.