### PR TITLE
Update ReceiveQueryResponse delay to 3s

### DIFF
--- a/SCPDiscordPlugin/RoleSync.cs
+++ b/SCPDiscordPlugin/RoleSync.cs
@@ -113,7 +113,7 @@ namespace SCPDiscord
 
     public static void ReceiveQueryResponse(UserInfo userInfo)
     {
-      Task.Delay(3000);
+      Thread.Sleep(1000);
       try
       {
         // For online servers this should always be one player but for offline servers it may match several

--- a/SCPDiscordPlugin/RoleSync.cs
+++ b/SCPDiscordPlugin/RoleSync.cs
@@ -113,7 +113,7 @@ namespace SCPDiscord
 
     public static void ReceiveQueryResponse(UserInfo userInfo)
     {
-      Task.Delay(1000);
+      Task.Delay(3000);
       try
       {
         // For online servers this should always be one player but for offline servers it may match several

--- a/SCPDiscordPlugin/RoleSync.cs
+++ b/SCPDiscordPlugin/RoleSync.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
+using System.Threading;
 using CentralAuth;
 using LabApi.Features.Wrappers;
 using Newtonsoft.Json;


### PR DESCRIPTION
After some tests on fully occupied server player who recently joined not found in Player.ReadyList for some reason. I suggest increasing delay to 3s to make sure it fully connected. Not an ideal solution, but helped me.