### PR TITLE
Rolesync v2

### DIFF
--- a/SCPDiscordPlugin/Config.cs
+++ b/SCPDiscordPlugin/Config.cs
@@ -389,21 +389,11 @@ namespace SCPDiscord
       ready = true;
     }
 
+    public static bool GetBool(string node) => configBools[node];
 
-    public static bool GetBool(string node)
-    {
-      return configBools[node];
-    }
+    public static string GetString(string node) => configStrings[node];
 
-    public static string GetString(string node)
-    {
-      return configStrings[node];
-    }
-
-    public static int GetInt(string node)
-    {
-      return configInts[node];
-    }
+    public static int GetInt(string node) => configInts[node];
 
     public static bool TryGetArray(string node, out string[] stringArray)
     {
@@ -417,57 +407,27 @@ namespace SCPDiscord
       return dict != null;
     }
 
-    public static void SetBool(string key, bool value)
-    {
-      configBools[key] = value;
-    }
+    public static void SetBool(string key, bool value) => configBools[key] = value;
 
-    public static void SetString(string key, string value)
-    {
-      configStrings[key] = value;
-    }
+    public static void SetString(string key, string value) => configStrings[key] = value;
 
-    public static void SetInt(string key, int value)
-    {
-      configInts[key] = value;
-    }
+    public static void SetInt(string key, int value) => configInts[key] = value;
 
-    public static void SetArray(string key, string[] value)
-    {
-      configArrays[key] = value;
-    }
+    public static void SetArray(string key, string[] value) => configArrays[key] = value;
 
-    public static void SetDict(string key, Dictionary<string, ulong> value)
-    {
-      configDicts[key] = value;
-    }
+    public static void SetDict(string key, Dictionary<string, ulong> value) => configDicts[key] = value;
 
     // TODO: Update paths with local/global paths
 
-    public static string GetSCPSLConfigDir()
-    {
-      return PathManager.SecretLab + "/";
-    }
+    public static string GetSCPSLConfigDir() => PathManager.SecretLab + "/";
 
-    public static string GetUserIDBansFile()
-    {
-      return BanHandler.GetPath(BanHandler.BanType.UserId);
-    }
+    public static string GetUserIDBansFile() => BanHandler.GetPath(BanHandler.BanType.UserId);
 
-    public static string GetIPBansFile()
-    {
-      return BanHandler.GetPath(BanHandler.BanType.IP);
-    }
+    public static string GetIPBansFile() => BanHandler.GetPath(BanHandler.BanType.IP);
 
-    public static string GetConfigDir()
-    {
-      return $"{SCPDiscord.plugin.GetConfigDirectory(false)}/";
-    }
+    public static string GetConfigDir() => $"{SCPDiscord.plugin.GetConfigDirectory(false)}/";
 
-    public static string GetConfigPath()
-    {
-      return GetConfigDir() + "config.yml";
-    }
+    public static string GetConfigPath() => GetConfigDir() + "config.yml";
 
     public static string GetLanguageDir()
     {
@@ -493,10 +453,7 @@ namespace SCPDiscord
       }
     }
 
-    public static string GetRolesyncPath()
-    {
-      return GetRolesyncDir() + "rolesync.json";
-    }
+    public static string GetRoleSyncPath() => GetRolesyncDir() + "rolesync.json";
 
     public static string GetMutesDir()
     {
@@ -510,10 +467,7 @@ namespace SCPDiscord
       }
     }
 
-    public static string GetMutesPath()
-    {
-      return GetMutesDir() + "mutes.json";
-    }
+    public static string GetMutesPath() => GetMutesDir() + "mutes.json";
 
     public static string GetPlaytimeDir()
     {
@@ -527,26 +481,17 @@ namespace SCPDiscord
       }
     }
 
-    public static string GetPlaytimePath()
-    {
-      return GetPlaytimeDir() + "playtime.json";
-    }
+    public static string GetPlaytimePath() => GetPlaytimeDir() + "playtime.json";
 
-    public static string GetReservedSlotDir()
-    {
-      // From ConfigSharing.Reload
-      return ConfigSharing.Paths[3];
-    }
+    // From ConfigSharing.Reload
+    public static string GetReservedSlotDir() => ConfigSharing.Paths[3];
 
-    public static string GetReservedSlotPath()
-    {
-      // From ConfigSharing.Reload
-      return ConfigSharing.Paths[3] + "UserIDReservedSlots.txt";
-    }
+    // From ConfigSharing.Reload
+    public static string GetReservedSlotPath() => ConfigSharing.Paths[3] + "UserIDReservedSlots.txt";
 
     public static void ValidateConfig(SCPDiscord plugin)
     {
-      StringBuilder sb = new StringBuilder();
+      StringBuilder sb = new();
       sb.Append("||||||||||||| SCPDISCORD CONFIG VALIDATOR ||||||||||||||\n");
       sb.Append("\n------------ Config strings ------------\n");
       foreach (KeyValuePair<string, string> node in configStrings)

--- a/SCPDiscordPlugin/Language.cs
+++ b/SCPDiscordPlugin/Language.cs
@@ -22,7 +22,7 @@ namespace SCPDiscord
     private static JObject emoteOverrides;
 
     // All default languages included in the .dll
-    private static readonly Dictionary<string, string> defaultLanguages = new Dictionary<string, string>
+    private static readonly Dictionary<string, string> defaultLanguages = new()
     {
       { "brazilian-portuguese", Utilities.ReadManifestData("Languages.brazilian-portuguese.yml") },
       { "emote-overrides",      Utilities.ReadManifestData("Languages.emote-overrides.yml")      },
@@ -118,8 +118,7 @@ namespace SCPDiscord
         foreach (KeyValuePair<string, string> variable in variables)
         {
           // Wait until after the regex replacements to add the player names
-          if (variable.Key == "name"
-              || variable.Key == "attacker-name"
+          if (variable.Key is "name" or "attacker-name"
               || variable.Key == "player-name"
               || variable.Key == "disarmer-name"
               || variable.Key == "target-name"

--- a/SCPDiscordPlugin/RoleSync.cs
+++ b/SCPDiscordPlugin/RoleSync.cs
@@ -138,7 +138,7 @@ namespace SCPDiscord
         Logger.Debug("[RS] Looking for player with SteamID/IP: " + steamIDOrIP);
         foreach (Player player in Player.ReadyList)
         {
-          Logger.Debug("[RS] Trying player " + player.PlayerId + ": SteamID " + player.UserId + " IP " + player.IpAddress);
+          Logger.Debug($"[RS] Trying player \"{player.PlayerId}\": SteamID {player.UserId} IP {player.IpAddress}");
           if (player.UserId == steamIDOrIP)
           {
             Logger.Debug("[RS] Matching SteamID found");
@@ -202,7 +202,7 @@ namespace SCPDiscord
           continue;
         }
 
-        Logger.Debug("[RS] User has discord role " + keyValuePair.Key + ", scheduling configured commands...");
+        Logger.Debug($"[RS] User has discord role {keyValuePair.Key}, scheduling configured commands...");
 
         foreach (string unparsedCommand in keyValuePair.Value)
         {
@@ -216,7 +216,7 @@ namespace SCPDiscord
           SCPDiscord.plugin.sync.ScheduleRoleSyncCommand(command);
         }
 
-        Logger.Info("Synced " + player.Nickname + " (" + userInfo.SteamIDOrIP + ") with Discord role id " + keyValuePair.Key);
+        Logger.Info($"Synced \"{player.Nickname}\" ({userInfo.SteamIDOrIP}) with Discord role id {keyValuePair.Key}");
         return;
       }
     }
@@ -247,19 +247,21 @@ namespace SCPDiscord
         // Compatibility mode (pre 3.4.0)
         if (compatibilityMode)
         {
-          Logger.Info("Running rolesync in compatibility mode for " + player.Nickname + " (" + userInfo.SteamIDOrIP + ").");
+          Logger.Info($"Running rolesync in compatibility mode for \"{player.Nickname}\" ({userInfo.SteamIDOrIP}).");
           RunRoleCommandsCompat(userInfo, player, variables);
         }
         else
         {
-          foreach (RoleCommands roleCommands in config.Values)
+          Logger.Info($"Running rolesync for \"{player.Nickname}\" ({userInfo.SteamIDOrIP}).");
+          foreach (KeyValuePair<string, RoleCommands> role in config)
           {
-            if (roleCommands.roleIDs.Length == 0 || roleCommands.roleIDs.Any(id => userInfo.RoleIDs.Contains(id)))
+            if (role.Value.roleIDs.Length == 0 || role.Value.roleIDs.Any(id => userInfo.RoleIDs.Contains(id)))
             {
-              Logger.Info("Running rolesync for " + player.Nickname + " (" + userInfo.SteamIDOrIP + ").");
-              RunRoleCommands(roleCommands, userInfo, player, variables);
-              break;
+              Logger.Debug($"[RS] Player {player.DisplayName} has role \"{role.Key}\", entering it...");
+              RunRoleCommands(role.Value, userInfo, player, variables);
+              return;
             }
+            Logger.Debug($"[RS] Player {player.DisplayName} does not have role \"{role.Key}\".");
           }
         }
       }

--- a/SCPDiscordPlugin/RoleSync.cs
+++ b/SCPDiscordPlugin/RoleSync.cs
@@ -13,14 +13,17 @@ namespace SCPDiscord
 {
   public static class RoleSync
   {
-    public struct RoleCommands
+    public class RoleCommands
     {
-      public ulong roleID;
-      public string[] commands;
-      public RoleCommands[] subRoles;
+      [JsonProperty("ids")]
+      public ulong[] roleIDs = [];
+      [JsonProperty("commands")]
+      public string[] commands = [];
+      [JsonProperty("sub-roles")]
+      public Dictionary<string, RoleCommands> subRoles = new();
     }
 
-    internal static List<RoleCommands> config = [];
+    internal static Dictionary<string, RoleCommands> config = [];
 
     // Old rolesync config format for backward compatibility (pre 3.4.0)
     internal static bool compatibilityMode = false;
@@ -174,7 +177,7 @@ namespace SCPDiscord
 
       foreach (Player player in matchingPlayers)
       {
-        foreach (KeyValuePair<ulong, string[]> keyValuePair in roleSyncConfCompat)
+        foreach (KeyValuePair<ulong, string[]> keyValuePair in configCompat)
         {
           if (!userInfo.RoleIDs.Contains(keyValuePair.Key))
           {

--- a/SCPDiscordPlugin/RoleSync.cs
+++ b/SCPDiscordPlugin/RoleSync.cs
@@ -198,7 +198,7 @@ namespace SCPDiscord
       {
         if (!userInfo.RoleIDs.Contains(keyValuePair.Key))
         {
-          Logger.Debug("[RS] User has discord role " + keyValuePair.Key + ": " + userInfo.RoleIDs.Contains(keyValuePair.Key));
+          Logger.Debug("[RS] User does not have discord role " + keyValuePair.Key);
           continue;
         }
 
@@ -217,6 +217,7 @@ namespace SCPDiscord
         }
 
         Logger.Info("Synced " + player.Nickname + " (" + userInfo.SteamIDOrIP + ") with Discord role id " + keyValuePair.Key);
+        return;
       }
     }
 

--- a/SCPDiscordPlugin/ServerCommands/GrantVanillaRankCommand.cs
+++ b/SCPDiscordPlugin/ServerCommands/GrantVanillaRankCommand.cs
@@ -29,18 +29,18 @@ namespace SCPDiscord.Commands
       List<Player> matchingPlayers = new List<Player>();
       try
       {
-        Logger.Debug("Looking for player with SteamID/PlayerID: " + steamIDOrPlayerID);
+        Logger.Debug("[GVR] Looking for player with SteamID/PlayerID: " + steamIDOrPlayerID);
         foreach (Player pl in Player.ReadyList)
         {
-          Logger.Debug("Player " + pl.PlayerId + ": SteamID " + pl.UserId + " PlayerID " + pl.PlayerId);
+          Logger.Debug("[GVR] Player " + pl.PlayerId + ": SteamID " + pl.UserId + " PlayerID " + pl.PlayerId);
           if (pl.GetParsedUserID() == steamIDOrPlayerID)
           {
-            Logger.Debug("Matching SteamID found");
+            Logger.Debug("[GVR] Matching SteamID found");
             matchingPlayers.Add(pl);
           }
           else if (pl.PlayerId.ToString() == steamIDOrPlayerID)
           {
-            Logger.Debug("Matching playerID found");
+            Logger.Debug("[GVR] Matching playerID found");
             matchingPlayers.Add(pl);
           }
         }

--- a/SCPDiscordPlugin/ServerCommands/SetNickname.cs
+++ b/SCPDiscordPlugin/ServerCommands/SetNickname.cs
@@ -29,18 +29,18 @@ namespace SCPDiscord.Commands
       List<Player> matchingPlayers = new List<Player>();
       try
       {
-        Logger.Debug("Looking for player with SteamID/PlayerID: " + steamIDOrPlayerID);
+        Logger.Debug("[SN] Looking for player with SteamID/PlayerID: " + steamIDOrPlayerID);
         foreach (Player pl in Player.ReadyList)
         {
-          Logger.Debug("Player " + pl.PlayerId + ": SteamID " + pl.UserId + " PlayerID " + pl.PlayerId);
+          Logger.Debug("[SN] Player " + pl.PlayerId + ": SteamID " + pl.UserId + " PlayerID " + pl.PlayerId);
           if (pl.GetParsedUserID() == steamIDOrPlayerID)
           {
-            Logger.Debug("Matching SteamID found");
+            Logger.Debug("[SN] Matching SteamID found");
             matchingPlayers.Add(pl);
           }
           else if (pl.PlayerId.ToString() == steamIDOrPlayerID)
           {
-            Logger.Debug("Matching playerID found");
+            Logger.Debug("[SN] Matching playerID found");
             matchingPlayers.Add(pl);
           }
         }

--- a/SCPDiscordPlugin/SynchronousExecutor.cs
+++ b/SCPDiscordPlugin/SynchronousExecutor.cs
@@ -38,12 +38,12 @@ namespace SCPDiscord
           continue;
         }
 
-        Dictionary<string, string> variables = new Dictionary<string, string>
+        Dictionary<string, string> variables = new()
         {
           { "feedback", response }
         };
 
-        EmbedMessage embed = new EmbedMessage
+        EmbedMessage embed = new()
         {
           Colour = EmbedMessage.Types.DiscordColour.Orange,
           ChannelID = command.ChannelID,

--- a/SCPDiscordPlugin/SynchronousExecutor.cs
+++ b/SCPDiscordPlugin/SynchronousExecutor.cs
@@ -55,7 +55,7 @@ namespace SCPDiscord
 
       while (queuedRoleSyncCommands.TryDequeue(out string stringCommand))
       {
-        Logger.Debug("RoleSync command response: " + Server.RunCommand(stringCommand));
+        Logger.Debug("[SE] RoleSync command response: " + Server.RunCommand(stringCommand));
       }
     }
 

--- a/SCPDiscordPlugin/config.yml
+++ b/SCPDiscordPlugin/config.yml
@@ -93,43 +93,45 @@ settings:
 # discord-username
 # discord-userid
 # There are some more player variables you can use here, but they are mostly irrelevant, check the list in APIExtensions.cs on GitHub for the full list.
-rolesync:
-    - "add-role-id-here":
-        - "scpd grantvanillarank <var:player-userid> moderator"
-        - "scpd grantreservedslot <var:player-userid> @<var:discordusername> (<var:discordid>)"
-        - "/pbc <var:player-id> 3 Moderator role synced from Discord."
 
-    - "add-another-role-id-here":
-        - "scpd grantvanillarank <var:player-userid> donator"
-        - "scpd grantreservedslot <var:player-userid> @<var:discordusername> (<var:discordid>)"
-        - "/pbc <var:player-id> 3 Donator role synced from Discord."
+# OLD CONFIG FORMAT
+#rolesync:
+#    - "add-role-id-here":
+#        - "scpd grantvanillarank <var:player-userid> moderator"
+#        - "scpd grantreservedslot <var:player-userid> @<var:discordusername> (<var:discordid>)"
+#        - "/pbc <var:player-id> 3 Moderator role synced from Discord."
+#
+#    - "add-another-role-id-here":
+#        - "scpd grantvanillarank <var:player-userid> donator"
+#        - "scpd grantreservedslot <var:player-userid> @<var:discordusername> (<var:discordid>)"
+#        - "/pbc <var:player-id> 3 Donator role synced from Discord."
+#
+#    - "add-everyone-role-id-here":
+#        - "scpd removereservedslot <var:player-userid>"
 
-    - "add-everyone-role-id-here":
-        - "scpd removereservedslot <var:player-userid>"
-
+# NEW CONFIG FORMAT
 # TODO: It should still probably just trigger the first role in each list
-rolesync-v2:
-    - staff-role:
-        ids: [ "add-role-id-here" ]
+rolesync:
+    staff-role:
+        ids: [ 123 ]
         commands:
             - "scpd grantreservedslot <var:player-userid> @<var:discordusername> (<var:discordid>)"
         sub-roles:
-            - admin-role:
-                  ids: [ "add-role-id-here" ]
-                  commands:
-                      - "scpd grantvanillarank <var:player-userid> admin"
-                      - "/pbc <var:player-id> 3 Admin role synced from Discord."
-                  sub-roles:
-            - moderator-role:
-                  ids: [ "add-role-id-here" ]
-                  commands:
-                      - "scpd grantvanillarank <var:player-userid> admin"
-                      - "/pbc <var:player-id> 3 Admin role synced from Discord."
-                  sub-roles:
-    - everyone-else:
-          ids: [ 0 ]
-          commands:
-              - "scpd removereservedslot <var:player-userid>"
+            admin-role:
+              ids: [ 12345 ]
+              commands:
+                  - "scpd grantvanillarank <var:player-userid> admin"
+                  - "/pbc <var:player-id> 3 Admin role synced from Discord."
+              sub-roles: []
+            moderator-role:
+              ids: [ 54321 ]
+              commands:
+                  - "scpd grantvanillarank <var:player-userid> admin"
+                  - "/pbc <var:player-id> 3 Admin role synced from Discord."
+    everyone-else:
+      ids: [ 0 ]
+      commands:
+          - "scpd removereservedslot <var:player-userid>"
 
 # Name your channels here, this name is used in the channels section below.
 # The left value is a name of your choice and the right is a channel id you want it to represent in the lists below.

--- a/SCPDiscordPlugin/config.yml
+++ b/SCPDiscordPlugin/config.yml
@@ -83,7 +83,7 @@ settings:
 
 # Sets commands to run whenever someone with a synced Discord rank joins the server,
 # only the highest command in the list that matches the player is executed.
-# Turn on debug above to see console feedback when the commands are used.
+# Turn on debug logs above to see console feedback when the commands are used.
 # Valid variables:
 # player-userid
 # player-id
@@ -106,6 +106,30 @@ rolesync:
 
     - "add-everyone-role-id-here":
         - "scpd removereservedslot <var:player-userid>"
+
+# TODO: It should still probably just trigger the first role in each list
+rolesync-v2:
+    - staff-role:
+        ids: [ "add-role-id-here" ]
+        commands:
+            - "scpd grantreservedslot <var:player-userid> @<var:discordusername> (<var:discordid>)"
+        sub-roles:
+            - admin-role:
+                  ids: [ "add-role-id-here" ]
+                  commands:
+                      - "scpd grantvanillarank <var:player-userid> admin"
+                      - "/pbc <var:player-id> 3 Admin role synced from Discord."
+                  sub-roles:
+            - moderator-role:
+                  ids: [ "add-role-id-here" ]
+                  commands:
+                      - "scpd grantvanillarank <var:player-userid> admin"
+                      - "/pbc <var:player-id> 3 Admin role synced from Discord."
+                  sub-roles:
+    - everyone-else:
+          ids: [ 0 ]
+          commands:
+              - "scpd removereservedslot <var:player-userid>"
 
 # Name your channels here, this name is used in the channels section below.
 # The left value is a name of your choice and the right is a channel id you want it to represent in the lists below.


### PR DESCRIPTION
Added support for new rolesync config:

```yaml
rolesync:
  staff-role:
    ids: [ 478633725534666752 ]
    commands:
      - "scpd grantreservedslot <var:player-userid> @<var:discordusername> (<var:discordid>)"
    sub-roles:
      admin-role:
        ids: [ 430474354875432960 ]
        commands:
          - "scpd grantvanillarank <var:player-userid> admin"
          - "/pbc <var:player-id> 3 Admin role synced from Discord."
        sub-roles: {}
      moderator-role:
        ids: [ 439020448710262784 ]
        commands:
          - "scpd grantvanillarank <var:player-userid> moderator"
          - "/pbc <var:player-id> 3 Moderator role synced from Discord."
  everyone-else:
    ids: [ 0 ]
    commands:
      - "scpd removereservedslot <var:player-userid>"
```

In this example anyone with the staff role gets a reserved slot but only those who have both the staff role and either and admin or moderator role gets their rank shown ingame. Like before the user only gets the commands from the first role found in each list but extra role checks can be added as sub roles.

If they do not have the staff role their reserved slot is removed.

Closes #230 